### PR TITLE
Fix package

### DIFF
--- a/ob-diagrams.el
+++ b/ob-diagrams.el
@@ -60,3 +60,4 @@
         ))))
 
 (provide 'ob-diagrams)
+;;; ob-diagrams.el ends here

--- a/ob-diagrams.el
+++ b/ob-diagrams.el
@@ -46,16 +46,15 @@
       (let ((script-file (org-babel-temp-file "diagrams-input")))
         (with-temp-file script-file (insert body))
         (message "%s \"%s\"" org-diagrams-executable script-file)
-        (setq output
-                  (shell-command-to-string
-                   (format
-                    "%s \"%s\" -o\"%s\" -w%s"
-                    org-diagrams-executable
-                    (org-babel-process-file-name
-                     script-file)
-                    out-file
-                    (cdr (assoc :width params)))))
-        (message output)
+        (let ((output (shell-command-to-string
+                       (format
+                        "%s \"%s\" -o\"%s\" -w%s"
+                        org-diagrams-executable
+                        (org-babel-process-file-name
+                         script-file)
+                        out-file
+                        (cdr (assoc :width params))))))
+          (message output))
         nil ;; signal that output has already been written to file
         ))))
 


### PR DESCRIPTION
- Add package footer for packaging convention
- Use local variable instead of free variable

`package-buffer-info` function is failed by 1st problem.

```
Package lacks a footer line in file ob-diagrams.el
```

There are following byte-compile about 2nd problem.

```
In org-babel-execute:diagrams:
ob-diagrams.el:59:18:Warning: assignment to free variable ‘output’
ob-diagrams.el:59:18:Warning: reference to free variable ‘output’
```
